### PR TITLE
Disable HA on pool before shutdown

### DIFF
--- a/slave/xen/xen-shutdown.sh
+++ b/slave/xen/xen-shutdown.sh
@@ -36,6 +36,9 @@ main () {
 	log_date "xen-shutdown.sh version $version"
 	log_date "==============================================================================="
 
+        log_date "Disable HA for pool..."
+	xe pool-ha-disable
+	
 	# Get UUIDs of all running VMs
 	vm_uuids=( $(xe vm-list power-state=running is-control-domain=false --minimal | tr , "\n" ) )
 

--- a/slave/xen/xen-shutdown.sh
+++ b/slave/xen/xen-shutdown.sh
@@ -36,7 +36,7 @@ main () {
 	log_date "xen-shutdown.sh version $version"
 	log_date "==============================================================================="
 
-        log_date "Disable HA for pool..."
+	log_date "Disable HA for pool..."
 	xe pool-ha-disable
 	
 	# Get UUIDs of all running VMs


### PR DESCRIPTION
During testing of your shutdown script, my pool refuses to shutdown if HA is enabled... This PR will disable HA before attempting to shutdown vm's and hosts.